### PR TITLE
Add Prefixing, Postfixing to Query Output

### DIFF
--- a/tools/sigma/backends/splunk.py
+++ b/tools/sigma/backends/splunk.py
@@ -42,6 +42,9 @@ class SplunkBackend(SingleTextQueryBackend):
     mapExpression = "%s=%s"
     mapListsSpecialHandling = True
     mapListValueExpression = "%s IN %s"
+    options = SingleTextQueryBackend.options + (
+        ("stats_command", "stats", "Default stats command used within the condition statement", None),
+    )
 
     def generateMapItemListNode(self, key, value):
         if not set([type(val) for val in value]).issubset({str, int}):
@@ -56,17 +59,17 @@ class SplunkBackend(SingleTextQueryBackend):
         if agg.groupfield == None:
             if agg.aggfunc_notrans == 'count':
                 if agg.aggfield == None :
-                    return " | eventstats count as val | search val %s %s" % (agg.cond_op, agg.condition)
+                    return " | %s count as val | search val %s %s" % (self.stats_command, agg.cond_op, agg.condition)
                 else:
                     agg.aggfunc_notrans = 'dc'
-            return " | eventstats %s(%s) as val | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
+            return " | %s %s(%s) as val | search val %s %s" % (self.stats_command, agg.aggfunc_notrans, agg.aggfield or "", agg.cond_op, agg.condition)
         else:
             if agg.aggfunc_notrans == 'count':
                 if agg.aggfield == None :
-                    return " | eventstats count as val by %s| search val %s %s" % (agg.groupfield, agg.cond_op, agg.condition)
+                    return " | %s count as val by %s| search val %s %s" % (self.stats_command, agg.groupfield, agg.cond_op, agg.condition)
                 else:
                     agg.aggfunc_notrans = 'dc'
-            return " | eventstats %s(%s) as val by %s | search val %s %s" % (agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
+            return " | %s %s(%s) as val by %s | search val %s %s" % (self.stats_command, agg.aggfunc_notrans, agg.aggfield or "", agg.groupfield or "", agg.cond_op, agg.condition)
 
 
     def generate(self, sigmaparser):

--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -75,10 +75,17 @@ class SigmaCollectionParser:
 
     def generate(self, backend):
         """Calls backend for all parsed rules"""
-        return filter(
-                lambda x: bool(x),      # filter None's and empty strings
-                [ backend.generate(parser) for parser in self.parsers ]
-                )
+        backend_name = backend.identifier
+        rules = list()
+        for parser in self.parsers:
+            yaml = parser.parsedyaml
+            search_prefix = yaml.get("search_prefix", {}).get(backend_name, "")
+            search_postfix = yaml.get("search_postfix", {}).get(backend_name, "")
+            baserule = backend.generate(parser)
+            # Ensure prefix and postfix don't interfere with filtering Nones and Empty Strings
+            rule = search_prefix + baserule + search_postfix if baserule else baserule
+            rules.append(rule)
+        return filter(lambda x: bool(x), rules) # filter None's and empty strings
 
     def __iter__(self):
         return iter([parser.parsedyaml for parser in self.parsers])

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -205,7 +205,7 @@ def main():
         order = 0
         for conf_name in cmdargs.config:
             try:
-                sigmaconfig = scm.get(conf_name)
+                sigmaconfig = scm.get(conf_name) # Parses Conf File, Fetches Basic Info From Config File
                 if sigmaconfig.order is not None:
                     if sigmaconfig.order <= order and not cmdargs.shoot_yourself_in_the_foot:
                         print("The configurations were provided in the wrong order (order key check in config file)", file=sys.stderr)
@@ -278,7 +278,7 @@ def main():
                 f = sigmafile
             else:
                 f = sigmafile.open(encoding='utf-8')
-            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter, sigmafile)
+            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter, sigmafile) # Start of interesting parsing
             results = parser.generate(backend)
 
             nb_result = len(list(copy.deepcopy(results)))


### PR DESCRIPTION
Sigma originally had no plans to add literal query prefixes or postfixes
to generated query outputs, so it had to be added. Reason for including them
is to better control whitelisting, at least on a per-backend basis.

This was achieved by adding two new fields to the Sigma rule's YAML
Specification: search_prefix and search_postfix.

This, of course, comes at a cost of portability to other search tools,
but for our organization, we decided that there's always going to be a
mountain of technical debt to repay when switching platforms, and the
benefits of including whitelisting within this  platform far outweighs
the technical debt incurred.